### PR TITLE
Add BibDesk formatting and ORCID DOI import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Extracts digital object identifiers (DOIs) from strings supplied on the command 
 ## Usage
 usage: blib [-h] [--output {md,bib,txt,rtf,review,doi,data}] [--clip | --no-clip]
             [--title | --no-title] [--abbrev | --no-abbrev]
-            [--authors AUTHORS] [--etal ETAL] [--format FORMAT]
+            [--authors AUTHORS] [--etal ETAL] [--format FORMAT] [--orcid ORCID]
             [doi ...]
 
 fetch bibtex entries from a list of strings containing DOIs.
@@ -36,6 +36,7 @@ options:
   --authors AUTHORS     number of authors to include in output
   --etal ETAL           text to use for "et al"
   --format FORMAT       BibDesk autogeneration format string used by md/txt/rtf output
+  --orcid ORCID         ORCID iD in the format 0000-0000-0000-0000
 
 ## Output formats
 
@@ -48,6 +49,14 @@ blib --output txt --format "%A[, ][ ]2, %t (%Y)" 10.1038/s41563-019-0386-4
 
 This makes the custom format responsible for the whole citation string. If you want the cite key in the output you can
 include it via `%f{Cite Key}`.
+
+You can also fetch works from an ORCID record instead of supplying DOI/arXiv identifiers directly:
+
+```sh
+blib --orcid 0000-0003-4843-5516
+```
+
+When ORCID metadata includes publication dates, blib de-duplicates returned DOIs and processes them in chronological order.
 
 ### bib
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Extracts digital object identifiers (DOIs) from strings supplied on the command 
 - Cannot fix mistakes in the cross ref entry (e.g. italic text which gets butted up to the next word).
 
 ## Usage
-usage: blib [-h] [--output {bib,txt,rtf,review}] [--clip | --no-clip]
+usage: blib [-h] [--output {md,bib,txt,rtf,review,doi,data}] [--clip | --no-clip]
             [--title | --no-title] [--abbrev | --no-abbrev]
-            [--authors AUTHORS] [--etal ETAL]
+            [--authors AUTHORS] [--etal ETAL] [--format FORMAT]
             [doi ...]
 
 fetch bibtex entries from a list of strings containing DOIs.
@@ -27,7 +27,7 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --output {bib,txt,rtf,review}
+  --output {md,bib,txt,rtf,review,doi,data}
                         output format (default: bib)
   --clip, --no-clip     copy results to clipboard (default: True)
   --title, --no-title   include title in output (default: True)
@@ -35,8 +35,19 @@ options:
                         abbreviate journal name in output (default: True)
   --authors AUTHORS     number of authors to include in output
   --etal ETAL           text to use for "et al"
+  --format FORMAT       BibDesk autogeneration format string used by md/txt/rtf output
 
 ## Output formats
+
+The `md`, `txt`, and `rtf` formatters can optionally be overridden with `--format` using BibDesk's
+autogeneration syntax. For example:
+
+```sh
+blib --output txt --format "%A[, ][ ]2, %t (%Y)" 10.1038/s41563-019-0386-4
+```
+
+This makes the custom format responsible for the whole citation string. If you want the cite key in the output you can
+include it via `%f{Cite Key}`.
 
 ### bib
 
@@ -47,7 +58,7 @@ A standard bibtex output:
   author    = {Fern{\'a}ndez-Pacheco, Amalio and Vedmedenko, Elena and Ummelen, Fanny and Mansell, Rhodri and Petit, Doroth{\'e}e and Cowburn, Russell P.},
   title     = {{Symmetry}-breaking interlayer {Dzyaloshinskii}–{Moriya} interactions in synthetic antiferromagnets},
   journal   = {Nat. Mater.},
-  issue     = {7},
+  number    = {7},
   volume    = {18},
   pages     = {679--684},
   year      = {2019},
@@ -75,5 +86,3 @@ A. Fernández-Pacheco *et al.*, Symmetry-breaking interlayer Dzyaloshinskii–Mo
 Long format rtf suitable for reviews in MS Word.
 
 Symmetry-breaking interlayer Dzyaloshinskii–Moriya interactions in synthetic antiferromagnets, A. Fernández-Pacheco, E. Vedmedenko, F. Ummelen, R. Mansell, D. Petit, and R.P. Cowburn, Nature Materials **18**, 679 (2019); https://doi.org/10.1038/s41563-019-0386-4
-
-

--- a/README.md
+++ b/README.md
@@ -40,23 +40,167 @@ options:
 
 ## Output formats
 
-The `md`, `txt`, and `rtf` formatters can optionally be overridden with `--format` using BibDesk's
-autogeneration syntax. For example:
+### BibDesk formatting
+
+The `md`, `txt`, and `rtf` formatters can optionally be overridden with `--format` using the
+autogeneration syntax popularized by [BibDesk](https://bibdesk.sourceforge.io/). If you want the
+full original reference, see the BibDesk manual page for
+[Autogeneration Format Syntax](https://bibdesk.sourceforge.io/manual/BibDeskHelp_92.html).
+
+In blib, the format string is responsible for the whole citation string.
+
+For example:
 
 ```sh
 blib --output txt --format "%A[, ][ ]2, %t (%Y)" 10.1038/s41563-019-0386-4
 ```
 
-This makes the custom format responsible for the whole citation string. If you want the cite key in the output you can
-include it via `%f{Cite Key}`.
+This produces output like:
 
-You can also fetch works from an ORCID record instead of supplying DOI/arXiv identifiers directly:
+```text
+Fernández-Pacheco A., Vedmedenko E., Symmetry-breaking interlayer Dzyaloshinskii-Moriya interactions in synthetic antiferromagnets (2019)
+```
+
+If you want the cite key in the output you can include it via `%f{Cite Key}`. For example:
+
+```sh
+blib --output txt --format "%A[, ][, ]1, %t. %f{Journal Abbreviation} %Y; %f{Volume}: %f{Pages}" 10.1038/s41563-019-0386-4
+```
+
+which gives a citation in the form:
+
+```text
+Fernández-Pacheco, A, Symmetry-breaking interlayer Dzyaloshinskii-Moriya interactions in synthetic antiferromagnets. Nat. Mater. 2019; 18: 679--684
+```
+
+The formatter works against blib's normalized bibliography fields, including:
+
+- `Author`
+- `Title`
+- `Journal`
+- `Journal Abbreviation`
+- `Volume`
+- `Number`
+- `Pages`
+- `Year`
+- `Month`
+- `DOI`
+- `URL`
+- `Cite Key`
+
+#### Syntax overview
+
+A format string is plain text mixed with `%` specifiers. Literal text is copied into the output and
+specifiers are replaced with values derived from the reference metadata.
+
+Many specifiers support:
+
+- square-bracket options such as `%A[, ][ ]2`
+- numeric parameters such as `%t20`
+- field names inside braces such as `%f{Journal Abbreviation}`
+
+#### Supported specifiers
+
+These specifiers are implemented in blib today.
+
+- `%a`
+  Uses author last names. Supports optional name separator, optional `et al.` text, a maximum number of names, and for lowercase `%a` a maximum family-name length.
+- `%A`
+  Uses author names with initials. Supports optional name separator, optional last-name/initial separator, optional `et al.` text, and a maximum number of names.
+- `%p`
+  Same idea as `%a`, but prefers editors when an editor field exists and otherwise falls back to authors.
+- `%P`
+  Same idea as `%A`, but prefers editors when an editor field exists and otherwise falls back to authors.
+- `%t`
+  Inserts the title, optionally truncated to a maximum character count.
+- `%T`
+  Inserts title words, with an optional "ignore short words" threshold and optional maximum word count.
+- `%y`
+  Two-digit year.
+- `%Y`
+  Full year.
+- `%m`
+  Numeric month.
+- `%k`
+  Concatenated keywords, with optional slash replacement, separator, and maximum keyword count.
+- `%f{Field}`
+  Inserts an arbitrary field. This is also how you access values like `Cite Key` and `BibTeX Type`.
+- `%w{Field}`
+  Inserts words from an arbitrary field, with optional separator characters, slash replacement, output separator, and maximum word count.
+- `%c{Field}`
+  Builds an acronym-like form from a field.
+- `%s{Field}`
+  Switches between "yes", "no", or "mixed" strings depending on whether a field is empty, populated, or multi-valued.
+- `%i{Key}`
+  Reads a document-info key when document metadata is available in the input record.
+- `%l`
+  Linked-file name without extension.
+- `%L`
+  Linked-file name with extension.
+- `%e`
+  Linked-file extension including the leading dot.
+- `%E`
+  Linked-file extension without the leading dot, with an optional default if no extension exists.
+- `%b`
+  Bibliography document file name without the extension.
+- `%%`, `%[`, `%]`, `%-`, `%0` ... `%9`
+  Escaped literal characters for percent signs, brackets, dashes, and digits after a specifier.
+
+#### Specifier notes
+
+- For `%a`, `%A`, `%p`, and `%P`, a negative author count means "take authors from the end".
+- For `%A` and `%P`, the second bracket option controls the separator between the surname and initials.
+- For `%t`, `%T`, `%f`, `%w`, `%c`, and `%i`, a numeric value of `0` means "do not limit".
+- `%f{Field}` and related field-based specifiers normalize field-name spelling, so `Journal Abbreviation`,
+  `journal_abbreviation`, and similar variants resolve to the same blib field.
+- For normal citation output, blib preserves readable text. In the documentation-style tests, a citekey-like
+  normalization mode is also exercised so the examples line up with BibDesk's generated-key behavior.
+
+#### Not implemented
+
+BibDesk also defines unique-value specifiers intended for auto-generated cite keys and file names:
+
+- `%u`
+- `%U`
+- `%n`
+
+blib currently rejects these with a clear error message. They are documented in the BibDesk manual,
+but are not yet part of blib's implemented subset.
+
+#### Examples
+
+Some useful patterns:
+
+- `%A[, ][ ]2, %t (%Y)`
+  Author initials, title, and year.
+- `%A[, ][, ]1, %t. %f{Journal Abbreviation} %Y; %f{Volume}: %f{Pages}`
+  A journal-style reference line.
+- `[%f{Cite Key}](%f{URL})`
+  A markdown link using the cite key as link text.
+
+The documentation-based tests in the codebase cover several examples derived from the BibDesk manual.
+
+### ORCID
+
+You can fetch works from an ORCID record instead of supplying DOI/arXiv identifiers directly:
 
 ```sh
 blib --orcid 0000-0003-4843-5516
 ```
 
-When ORCID metadata includes publication dates, blib de-duplicates returned DOIs and processes them in chronological order.
+The ORCID must be supplied in the form `0000-0000-0000-0000`.
+
+When using `--orcid`, blib:
+
+- fetches `https://pub.orcid.org/v3.0/<ORCID>/works`
+- extracts at most one DOI per ORCID work group
+- prefers a Crossref-sourced DOI when one is available for that work
+- otherwise uses the first source in the ORCID data that exposes a DOI
+- de-duplicates the resulting DOI list
+- sorts the DOI list chronologically when publication dates are available
+
+Any DOI lookups that fail are reported and processing continues. In `rtf` and `review` output these failures are
+rendered as red paragraphs so they are easy to spot after pasting into a document.
 
 ### bib
 

--- a/src/blib/citekey.py
+++ b/src/blib/citekey.py
@@ -2,23 +2,23 @@ from blib.utils import normalise_unicode_to_ascii
 
 
 def article_citekey(data):
-    citekey_author = normalise_unicode_to_ascii(data['authors'][0]['family']).replace(' ', '').replace('-', '')
-    citekey_journal = data['journal-abbrev'].replace(' ', '').replace('.', '').replace(':', '')
+    citekey_author = normalise_unicode_to_ascii(data['author'][0]['family']).replace(' ', '').replace('-', '')
+    citekey_journal = data['journal_abbreviation'].replace(' ', '').replace('.', '').replace(':', '')
 
     if "pages" not in data or data["pages"] is None:
-        return f'{citekey_author}_{citekey_journal}_{data["volume"]}_{data["published-date"]["year"]}'
+        return f'{citekey_author}_{citekey_journal}_{data["volume"]}_{data["year"]}'
     else:
-        return f'{citekey_author}_{citekey_journal}_{data["volume"]}_{data["pages"][0]}_{data["published-date"]["year"]}'
+        return f'{citekey_author}_{citekey_journal}_{data["volume"]}_{data["pages"][0]}_{data["year"]}'
 
 
 
 def misc_citekey(data):
-    citekey_author = normalise_unicode_to_ascii(data['authors'][0]['family']).replace(' ',
+    citekey_author = normalise_unicode_to_ascii(data['author'][0]['family']).replace(' ',
                                                                                       '').replace(
         '-', '')
     citekey_journal = data['eprint'].replace('.', '_')
 
     if "pages" not in data or data["pages"] is None:
-        return f'{citekey_author}_{citekey_journal}_{data["published-date"]["year"]}'
+        return f'{citekey_author}_{citekey_journal}_{data["year"]}'
     else:
-        return f'{citekey_author}_{citekey_journal}_{data["pages"][0]}_{data["published-date"]["year"]}'
+        return f'{citekey_author}_{citekey_journal}_{data["pages"][0]}_{data["year"]}'

--- a/src/blib/formatting/bibdesk_autogeneration.py
+++ b/src/blib/formatting/bibdesk_autogeneration.py
@@ -1,0 +1,480 @@
+import re
+
+from blib.citekey import article_citekey, misc_citekey
+from blib.utils import normalise_unicode_to_ascii
+
+
+class BibDeskFormatError(ValueError):
+    pass
+
+
+class BibDeskAutogenerationFormatter:
+    def __init__(self, format_string, encoder, citekey_mode=False):
+        self._format_string = format_string
+        self._encoder = encoder
+        self._citekey_mode = citekey_mode
+
+    def format(self, data):
+        result = []
+        i = 0
+        while i < len(self._format_string):
+            char = self._format_string[i]
+            if char != '%':
+                result.append(self._encode_literal(char))
+                i += 1
+                continue
+
+            if i + 1 >= len(self._format_string):
+                raise BibDeskFormatError("dangling '%' in format string")
+
+            specifier = self._format_string[i + 1]
+            text, i = self._expand_specifier(specifier, i + 2, data)
+            result.append(text)
+
+        return ''.join(result)
+
+    def _expand_specifier(self, specifier, index, data):
+        if specifier in '%[]-0123456789':
+            return self._encode_literal(specifier), index
+
+        if specifier in 'uUn':
+            raise BibDeskFormatError(f"specifier %{specifier} is not supported for blib output formatting")
+
+        if specifier in 'aApP':
+            options, index = self._parse_square_brackets(index)
+            index = self._consume_parameter_spacing(index)
+            number_text, index = self._parse_author_numbers(index, specifier)
+            return self._format_people(specifier, options, number_text, data), index
+
+        if specifier in 'tTk':
+            options, index = self._parse_square_brackets(index)
+            index = self._consume_parameter_spacing(index)
+            number_text, index = self._parse_number(index)
+            return self._format_simple_specifier(specifier, options, number_text, data), index
+
+        if specifier in 'lLeb':
+            return self._format_file_specifier(specifier, [], data), index
+
+        if specifier == 'E':
+            options, index = self._parse_square_brackets(index)
+            return self._format_file_specifier(specifier, options, data), index
+
+        if specifier in 'fwcsi':
+            field_name, index = self._parse_field_name(index)
+            options, index = self._parse_square_brackets(index)
+            index = self._consume_parameter_spacing(index)
+            number_text, index = self._parse_number(index)
+            return self._format_field_specifier(specifier, field_name, options, number_text, data), index
+
+        if specifier in 'yYm':
+            return self._format_date_specifier(specifier, data), index
+
+        raise BibDeskFormatError(f"unknown format specifier %{specifier}")
+
+    def _format_people(self, specifier, options, number_text, data):
+        prefer_editor = specifier in 'pP'
+        people = self._people(data, prefer_editor=prefer_editor)
+        if not people:
+            return ''
+
+        name_separator = options[0] if len(options) >= 1 else ''
+        max_names = 0
+        max_name_length = 0
+
+        if specifier in 'aApP':
+            max_names = number_text[0] if len(number_text) >= 1 else 0
+        if specifier in 'ap':
+            max_name_length = number_text[1] if len(number_text) >= 2 else 0
+
+        etal_text = ''
+        if specifier in 'aApP':
+            if specifier in 'AP':
+                initial_separator = options[1] if len(options) >= 2 else ''
+                etal_text = options[2] if len(options) >= 3 else ''
+            else:
+                initial_separator = ''
+                etal_text = options[1] if len(options) >= 2 else ''
+        else:
+            initial_separator = ''
+
+        selected_people, truncated = self._selected_people(people, max_names)
+        etal_count = None
+        if etal_text and etal_text[-1].isdigit():
+            etal_count = int(etal_text[-1])
+            etal_text = etal_text[:-1]
+
+        if truncated and etal_count is not None:
+            if max_names < 0:
+                selected_people = selected_people[-etal_count:]
+            else:
+                selected_people = selected_people[:etal_count]
+
+        if specifier in 'ap':
+            rendered_people = [
+                self._encode_generated(self._prepare_generated_text(self._truncate(name['family'], max_name_length)))
+                for name in selected_people
+            ]
+        else:
+            rendered_people = [
+                self._encode_generated(self._name_with_initials(name, initial_separator))
+                for name in selected_people
+            ]
+
+        rendered = name_separator.join(rendered_people)
+        if truncated and etal_text:
+            rendered += self._encode_generated(etal_text)
+
+        return rendered
+
+    def _format_simple_specifier(self, specifier, options, number_text, data):
+        if specifier == 't':
+            value = self._prepare_generated_text(self._field_text(data, 'title'))
+            max_length = int(number_text) if number_text else 0
+            return self._encode_generated(self._truncate(value, max_length))
+
+        if specifier == 'T':
+            ignore_length = int(options[0]) if options and options[0] else 3
+            max_words = int(number_text) if number_text else 0
+            value = self._words_from_text(self._field_text(data, 'title'), ignore_length, max_words)
+            value = self._prepare_generated_text(value)
+            return self._encode_generated(value)
+
+        if specifier == 'k':
+            slash_replacement = options[0] if len(options) >= 1 and options[0] else '/'
+            separator = options[1] if len(options) >= 2 else ''
+            max_keywords = int(number_text) if number_text else 0
+            keywords = self._keywords(data)
+            if max_keywords > 0:
+                keywords = keywords[:max_keywords]
+            keywords = [self._replace_slashes(keyword, slash_replacement) for keyword in keywords]
+            value = self._prepare_generated_text(separator.join(keywords))
+            return self._encode_generated(value)
+
+        raise BibDeskFormatError(f"unsupported simple specifier %{specifier}")
+
+    def _format_file_specifier(self, specifier, options, data):
+        if specifier == 'b':
+            bibliography = data.get('bibliography-file')
+            if not bibliography:
+                raise BibDeskFormatError("specifier %b requires bibliography-file metadata which is not available")
+            return self._encode_generated(re.sub(r'\.[^.]*$', '', bibliography))
+
+        linked_file = data.get('linked-file')
+        if not linked_file:
+            raise BibDeskFormatError(f"specifier %{specifier} requires linked-file metadata which is not available")
+
+        base_name, extension = re.match(r'^(.*?)(\.[^.]*)?$', linked_file).groups()
+
+        if specifier == 'l':
+            return self._encode_generated(base_name)
+        if specifier == 'L':
+            return self._encode_generated(linked_file)
+        if specifier == 'e':
+            return self._encode_generated(extension or '')
+        if specifier == 'E':
+            default_extension = options[0] if options else ''
+            if extension:
+                return self._encode_generated(extension.removeprefix('.'))
+            return self._encode_generated(default_extension)
+
+        raise BibDeskFormatError(f"unsupported file specifier %{specifier}")
+
+    def _format_field_specifier(self, specifier, field_name, options, number_text, data):
+        if specifier == 'f':
+            value = self._field_text(data, field_name)
+            slash_replacement = options[0] if len(options) >= 1 and options[0] else '/'
+            max_length = int(number_text) if number_text else 0
+            value = self._replace_slashes(value, slash_replacement)
+            value = self._prepare_generated_text(value)
+            return self._encode_generated(self._truncate(value, max_length))
+
+        if specifier == 'w':
+            value = self._field_text(data, field_name)
+            separator_characters = options[0] if len(options) >= 1 else ''
+            slash_replacement = options[1] if len(options) >= 2 and options[1] else '/'
+            separator = options[2] if len(options) >= 3 else ''
+            max_words = int(number_text) if number_text else 0
+            value = self._words_from_field(value, separator_characters, slash_replacement, separator, max_words)
+            value = self._prepare_generated_text(value)
+            return self._encode_generated(value)
+
+        if specifier == 'c':
+            value = self._field_text(data, field_name)
+            ignore_length = int(number_text) if number_text else 3
+            value = self._prepare_generated_text(self._initials_from_field(value, ignore_length))
+            return self._encode_generated(value)
+
+        if specifier == 's':
+            value = self._field_value(data, field_name)
+            yes_value = options[0] if len(options) >= 1 else ''
+            no_value = options[1] if len(options) >= 2 else ''
+            mixed_value = options[2] if len(options) >= 3 else yes_value
+            max_length = int(number_text) if number_text else 0
+            if isinstance(value, list):
+                if len(value) > 1:
+                    return self._encode_generated(self._truncate(self._prepare_generated_text(mixed_value), max_length))
+                if len(value) == 1:
+                    return self._encode_generated(self._truncate(self._prepare_generated_text(yes_value), max_length))
+                return self._encode_generated(self._truncate(self._prepare_generated_text(no_value), max_length))
+            if value:
+                return self._encode_generated(self._truncate(self._prepare_generated_text(yes_value), max_length))
+            return self._encode_generated(self._truncate(self._prepare_generated_text(no_value), max_length))
+
+        if specifier == 'i':
+            document_info = data.get('document-info', {})
+            value = document_info.get(field_name, '')
+            max_length = int(number_text) if number_text else 0
+            value = self._prepare_generated_text(str(value))
+            return self._encode_generated(self._truncate(value, max_length))
+
+        raise BibDeskFormatError(f"unsupported field specifier %{specifier}")
+
+    def _format_date_specifier(self, specifier, data):
+        year = str(data.get('year', '') or '')
+        month = str(data.get('month', '') or '')
+        if specifier == 'y':
+            return self._encode_generated(year[-2:] if year else '')
+        if specifier == 'Y':
+            return self._encode_generated(year)
+        if specifier == 'm':
+            return self._encode_generated(month)
+        raise BibDeskFormatError(f"unsupported date specifier %{specifier}")
+
+    def _consume_parameter_spacing(self, index):
+        while index < len(self._format_string) and self._format_string[index].isspace():
+            next_index = index + 1
+            if next_index < len(self._format_string) and (
+                self._format_string[next_index].isdigit()
+                or (
+                    self._format_string[next_index] == '-'
+                    and next_index + 1 < len(self._format_string)
+                    and self._format_string[next_index + 1].isdigit()
+                )
+            ):
+                index += 1
+                continue
+            break
+        return index
+
+    def _parse_square_brackets(self, index):
+        options = []
+        while index < len(self._format_string) and self._format_string[index] == '[':
+            index += 1
+            option = []
+            while index < len(self._format_string):
+                char = self._format_string[index]
+                if char == ']':
+                    index += 1
+                    break
+                if char == '%':
+                    if index + 1 >= len(self._format_string):
+                        raise BibDeskFormatError("dangling '%' inside [] in format string")
+                    escaped = self._format_string[index + 1]
+                    if escaped not in '%[]-0123456789':
+                        raise BibDeskFormatError("only escaped characters are allowed inside []")
+                    option.append(escaped)
+                    index += 2
+                    continue
+                option.append(char)
+                index += 1
+            else:
+                raise BibDeskFormatError("unterminated [] in format string")
+            options.append(''.join(option))
+        return options, index
+
+    def _parse_field_name(self, index):
+        if index >= len(self._format_string) or self._format_string[index] != '{':
+            raise BibDeskFormatError("field-based specifiers require a {Field} parameter")
+
+        index += 1
+        field_name = []
+        while index < len(self._format_string) and self._format_string[index] != '}':
+            field_name.append(self._format_string[index])
+            index += 1
+
+        if index >= len(self._format_string):
+            raise BibDeskFormatError("unterminated {Field} in format string")
+
+        return ''.join(field_name), index + 1
+
+    def _parse_author_numbers(self, index, specifier):
+        if index >= len(self._format_string):
+            return (), index
+
+        max_names = None
+        max_name_length = None
+
+        if self._format_string[index] == '-' and index + 1 < len(self._format_string) and self._format_string[index + 1].isdigit():
+            max_names = -int(self._format_string[index + 1])
+            index += 2
+        elif self._format_string[index].isdigit():
+            max_names = int(self._format_string[index])
+            index += 1
+
+        if specifier in 'ap' and index < len(self._format_string) and self._format_string[index].isdigit():
+            max_name_length = int(self._format_string[index])
+            index += 1
+
+        values = []
+        if max_names is not None:
+            values.append(max_names)
+        if max_name_length is not None:
+            values.append(max_name_length)
+        return tuple(values), index
+
+    def _parse_number(self, index):
+        if index >= len(self._format_string):
+            return '', index
+
+        start = index
+        if self._format_string[index] == '-':
+            index += 1
+        while index < len(self._format_string) and self._format_string[index].isdigit():
+            index += 1
+        if index == start or (index == start + 1 and self._format_string[start] == '-'):
+            return '', start
+        return self._format_string[start:index], index
+
+    def _people(self, data, prefer_editor=False):
+        if prefer_editor and data.get('editor'):
+            return data['editor']
+        return data.get('author', [])
+
+    def _selected_people(self, people, max_names):
+        if max_names == 0 or abs(max_names) >= len(people):
+            return list(people), False
+        if max_names < 0:
+            return list(people[max_names:]), True
+        return list(people[:max_names]), True
+
+    def _name_with_initials(self, person, initial_separator):
+        initials = []
+        given_name = person.get('given', '')
+        if isinstance(given_name, list):
+            given_name = ' '.join(given_name)
+        for name in str(given_name).split():
+            if not name:
+                continue
+            initials.append(name[:-1] if name.endswith('.') else name[0])
+        if initials:
+            return f'{person["family"]}{initial_separator}{".".join(initials)}.'
+        return person['family']
+
+    def _truncate(self, text, max_length):
+        if max_length <= 0:
+            return text
+        return text[:max_length]
+
+    def _replace_slashes(self, text, replacement):
+        if replacement == '/':
+            return text
+        return text.replace('/', replacement)
+
+    def _field_value(self, data, field_name):
+        normalized = self._normalize_field_name(field_name)
+        if normalized == 'citekey':
+            if data.get('bibtex_type') == 'article':
+                return article_citekey(data)
+            return misc_citekey(data)
+        if normalized == 'pages':
+            return self._pages_text(data)
+
+        for key, value in data.items():
+            if self._normalize_field_name(key) == normalized:
+                return value
+
+        return ''
+
+    def _field_text(self, data, field_name):
+        value = self._field_value(data, field_name)
+        if value is None:
+            return ''
+        if isinstance(value, list):
+            if value and isinstance(value[0], dict):
+                names = []
+                for person in value:
+                    given = person.get('given', '')
+                    if isinstance(given, list):
+                        given = ' '.join(given)
+                    parts = [str(given).strip(), person.get('family', '').strip()]
+                    names.append(' '.join(part for part in parts if part))
+                return ', '.join(names)
+            return ', '.join(str(item) for item in value)
+        return str(value)
+
+    def _pages_text(self, data):
+        pages = data.get('pages')
+        if pages is None:
+            return ''
+        if isinstance(pages, list):
+            if len(pages) == 1:
+                return str(pages[0])
+            return '--'.join(str(page) for page in pages)
+        return str(pages)
+
+    def _keywords(self, data):
+        keywords = data.get('keywords', [])
+        if isinstance(keywords, str):
+            return [keyword.strip() for keyword in re.split(r'[;:,]', keywords) if keyword.strip()]
+        return [str(keyword) for keyword in keywords]
+
+    def _words_from_text(self, text, ignore_length, max_words):
+        if max_words <= 0:
+            return text
+
+        words = text.split()
+        counted_words = 0
+        result = []
+        for word in words:
+            result.append(word)
+            plain_word = re.sub(r'^[^\w]+|[^\w]+$', '', word, flags=re.UNICODE)
+            if len(plain_word) > ignore_length:
+                counted_words += 1
+                if counted_words >= max_words:
+                    break
+
+        return ' '.join(result)
+
+    def _words_from_field(self, text, separator_characters, slash_replacement, separator, max_words):
+        replaced_text = self._replace_slashes(text, slash_replacement)
+        if separator_characters:
+            parts = [part for part in re.split(f'[{re.escape(separator_characters)}]+', replaced_text) if part]
+        else:
+            parts = re.findall(r'[\w]+', replaced_text, flags=re.UNICODE)
+
+        if max_words > 0:
+            parts = parts[:max_words]
+
+        return separator.join(parts)
+
+    def _initials_from_field(self, text, ignore_length):
+        parts = re.findall(r'[\w]+', text, flags=re.UNICODE)
+        initials = [part[0] for part in parts if len(part) > ignore_length]
+        return ''.join(initials)
+
+    def _normalize_field_name(self, field_name):
+        return re.sub(r'[^a-z0-9]+', '', field_name.lower())
+
+    def _prepare_generated_text(self, text):
+        if not self._citekey_mode:
+            return text
+
+        normalized = normalise_unicode_to_ascii(text)
+        normalized = re.sub(r'\s+', '-', normalized)
+        normalized = re.sub(r'[^A-Za-z0-9:;./-]+', '', normalized)
+        normalized = re.sub(r'-{2,}', '-', normalized)
+        return normalized
+
+    def _encode_generated(self, text):
+        return self._encode_text(text)
+
+    def _encode_literal(self, text):
+        return self._encode_text(text, fallback_to_raw=True)
+
+    def _encode_text(self, text, fallback_to_raw=False):
+        try:
+            return self._encoder.encode(text)
+        except RuntimeError:
+            if fallback_to_raw:
+                return text
+            raise

--- a/src/blib/formatting/bibtex.py
+++ b/src/blib/formatting/bibtex.py
@@ -15,7 +15,7 @@ class BibtexFormatter(Formatter):
 
     def format(self, data):
 
-        if data['entry'] == 'article':
+        if data['bibtex_type'] == 'article':
             citekey, fields = self._format_article(data)
         else:
             citekey, fields = self._format_misc(data)
@@ -23,7 +23,7 @@ class BibtexFormatter(Formatter):
         fields = ',\n'.join([f'  {key:9} = {{{value}}}' for key, value in fields.items()])
 
         return (
-            f"@{data['entry']}{{{citekey},\n"
+            f"@{data['bibtex_type']}{{{citekey},\n"
             f"{fields}\n"
             f"}}\n"
         )
@@ -31,16 +31,16 @@ class BibtexFormatter(Formatter):
     def _format_article(self, data):
         # We don't use a dictionary here because we want the printing to be ordered and deterministic
         fields = OrderedDict()
-        fields["author"] = self._authors(data["authors"])
+        fields["author"] = self._authors(data["author"])
         fields["title"] = self._encoder.encode(data["title"], nouns=True, chemicals=True)
 
-        if "journal-abbrev" in data and self._abbreviate_journals:
-            fields["journal"] = self._encoder.encode(data["journal-abbrev"])
+        if "journal_abbreviation" in data and self._abbreviate_journals:
+            fields["journal"] = self._encoder.encode(data["journal_abbreviation"])
         elif "journal" in data:
             fields["journal"] = self._encoder.encode(data["journal"])
 
-        if "issue" in data and data["issue"]:
-            fields["issue"] = data["issue"]
+        if "number" in data and data["number"]:
+            fields["number"] = data["number"]
 
         if "volume" in data and data["volume"]:
             fields["volume"] = data["volume"]
@@ -53,10 +53,10 @@ class BibtexFormatter(Formatter):
             elif len(data["pages"]) == 2:
                 fields["pages"] = f'{data["pages"][0]}--{data["pages"][1]}'
 
-        fields["year"] = data["published-date"]["year"]
+        fields["year"] = data["year"]
 
-        if "month" in data["published-date"] and data["published-date"]["month"]:
-            fields["month"] = data["published-date"]["month"]
+        if "month" in data and data["month"]:
+            fields["month"] = data["month"]
 
         if "publisher" in data and data["publisher"]:
             fields["publisher"] = self._encoder.encode(data["publisher"])
@@ -71,21 +71,21 @@ class BibtexFormatter(Formatter):
 
     def _format_misc(self, data):
 
-        standard_fields = ("entry", "authors", "title", "journal-abbrev", "journal", "issue", "volume",
-                           "pages", "published-date", "publisher", "doi", "url", "eprint")
+        standard_fields = ("bibtex_type", "author", "title", "journal_abbreviation", "journal", "number", "volume",
+                           "pages", "year", "month", "publisher", "doi", "url", "eprint")
 
         # We don't use a dictionary here because we want the printing to be ordered and deterministic
         fields = OrderedDict()
-        fields["author"] = self._authors(data["authors"])
+        fields["author"] = self._authors(data["author"])
         fields["title"] = self._encoder.encode(data["title"], nouns=True, chemicals=True)
 
-        if "journal-abbrev" in data and self._abbreviate_journals:
-            fields["journal"] = self._encoder.encode(data["journal-abbrev"])
+        if "journal_abbreviation" in data and self._abbreviate_journals:
+            fields["journal"] = self._encoder.encode(data["journal_abbreviation"])
         elif "journal" in data:
             fields["journal"] = self._encoder.encode(data["journal"])
 
-        if "issue" in data and data["issue"]:
-            fields["issue"] = data["issue"]
+        if "number" in data and data["number"]:
+            fields["number"] = data["number"]
 
         if "volume" in data and data["volume"]:
             fields["volume"] = data["volume"]
@@ -98,8 +98,8 @@ class BibtexFormatter(Formatter):
             elif len(data["pages"]) == 2:
                 fields["pages"] = f'{data["pages"][0]}--{data["pages"][1]}'
 
-        fields["year"] = data["published-date"]["year"]
-        fields["month"] = data["published-date"]["month"]
+        fields["year"] = data["year"]
+        fields["month"] = data["month"]
 
         if "publisher" in data and data["publisher"]:
             fields["publisher"] = self._encoder.encode(data["publisher"])

--- a/src/blib/formatting/data_formatter.py
+++ b/src/blib/formatting/data_formatter.py
@@ -23,16 +23,16 @@ class DataFormatter(Formatter):
     def _format(self, data):
         # We don't use a dictionary here because we want the printing to be ordered and deterministic
         fields = OrderedDict()
-        fields["author"] = self._authors(data["authors"])
+        fields["author"] = self._authors(data["author"])
         fields["title"] = self._encoder.encode(data["title"], nouns=True, chemicals=True)
 
-        if "journal-abbrev" in data and self._abbreviate_journals:
-            fields["journal"] = self._encoder.encode(data["journal-abbrev"])
+        if "journal_abbreviation" in data and self._abbreviate_journals:
+            fields["journal"] = self._encoder.encode(data["journal_abbreviation"])
         elif "journal" in data:
             fields["journal"] = self._encoder.encode(data["journal"])
 
-        if "issue" in data and data["issue"]:
-            fields["issue"] = data["issue"]
+        if "number" in data and data["number"]:
+            fields["number"] = data["number"]
 
         if "volume" in data and data["volume"]:
             fields["volume"] = data["volume"]
@@ -45,10 +45,10 @@ class DataFormatter(Formatter):
             elif len(data["pages"]) == 2:
                 fields["pages"] = f'{data["pages"][0]}--{data["pages"][1]}'
 
-        fields["year"] = data["published-date"]["year"]
+        fields["year"] = data["year"]
 
-        if "month" in data["published-date"] and data["published-date"]["month"]:
-            fields["month"] = data["published-date"]["month"]
+        if "month" in data and data["month"]:
+            fields["month"] = data["month"]
 
         if "publisher" in data and data["publisher"]:
             fields["publisher"] = self._encoder.encode(data["publisher"])

--- a/src/blib/formatting/markdown.py
+++ b/src/blib/formatting/markdown.py
@@ -1,5 +1,6 @@
 from blib.citekey import article_citekey, misc_citekey
 from blib.encoding.unicode_encoder import UnicodeEncoder
+from blib.formatting.bibdesk_autogeneration import BibDeskAutogenerationFormatter
 from .formatter import Formatter
 
 
@@ -9,28 +10,35 @@ class MarkdownFormatter(Formatter):
                  abbreviate_journals=True,
                  use_title=False,
                  max_authors=1,
-                 etal="et al."):
+                 etal="et al.",
+                 format_string=None):
         self._encoder = UnicodeEncoder()
         self._abbreviate_journals = abbreviate_journals
         self._use_title = use_title
         self._max_authors = max_authors
         self._etal = etal
+        self._format_string = format_string
+        self._bibdesk_formatter = None
+        if format_string:
+            self._bibdesk_formatter = BibDeskAutogenerationFormatter(format_string, self._encoder)
 
     def format(self, data):
+        if self._bibdesk_formatter:
+            return self._bibdesk_formatter.format(data)
 
         result = []
 
-        if data['entry'] == 'article':
+        if data['bibtex_type'] == 'article':
             citekey = article_citekey(data)
         else:
             citekey = misc_citekey(data)
 
         result.append(f"[#{citekey}]: ")
 
-        authors = self._authors(data['authors'])
+        authors = self._authors(data['author'])
 
         if authors:
-            result.append(f"{self._authors(data['authors'])}, ")
+            result.append(f"{self._authors(data['author'])}, ")
 
         if self._use_title:
             result.append(f"*{self._encoder.encode(data['title'])}*, ")
@@ -38,7 +46,7 @@ class MarkdownFormatter(Formatter):
         result.append("[")
 
         if self._abbreviate_journals:
-            result.append(f"{self._encoder.encode(data['journal-abbrev'])}")
+            result.append(f"{self._encoder.encode(data['journal_abbreviation'])}")
         else:
             result.append(f"{self._encoder.encode(data['journal'])}")
 
@@ -47,7 +55,7 @@ class MarkdownFormatter(Formatter):
         except TypeError:
             pages = data['pages']
 
-        result.append(f" **{data['volume']}**, {pages} ({data['published-date']['year']})")
+        result.append(f" **{data['volume']}**, {pages} ({data['year']})")
         result.append(f"]({data['url']})")
 
         return ''.join(result)

--- a/src/blib/formatting/richtext.py
+++ b/src/blib/formatting/richtext.py
@@ -109,7 +109,7 @@ class RichTextFormatter(TextFormatter):
 
 
     def header(self):
-        return r'{\rtf1\ansi\deff0 '
+        return r'{\rtf1\ansi\deff0{\colortbl;\red0\green0\blue255;\red255\green0\blue0;} '
 
     def footer(self):
         return r'}'

--- a/src/blib/formatting/richtext.py
+++ b/src/blib/formatting/richtext.py
@@ -1,4 +1,5 @@
 import blib.encoding
+from blib.formatting.bibdesk_autogeneration import BibDeskAutogenerationFormatter
 from blib.formatting.text_formatter import TextFormatter
 
 
@@ -8,17 +9,24 @@ class RichTextFormatter(TextFormatter):
                  abbreviate_journals=True,
                  use_title=False,
                  max_authors=1,
-                 etal="et al."):
+                 etal="et al.",
+                 format_string=None):
         TextFormatter.__init__(self,
                                abbreviate_journals=abbreviate_journals,
                                use_title=use_title,
                                max_authors=max_authors,
-                               etal=f"\i {etal}\i0" if etal else "")
+                               etal=f"\i {etal}\i0" if etal else "",
+                               format_string=format_string)
         self._encoder = blib.encoding.RichTextEncoder()
+        if format_string:
+            self._bibdesk_formatter = BibDeskAutogenerationFormatter(format_string, self._encoder)
 
     def format(self, data):
+        if self._bibdesk_formatter:
+            citation = self._bibdesk_formatter.format(data)
+            return rf'{{\pard {citation} \par}}'
 
-        if data['entry'] == 'article':
+        if data['bibtex_type'] == 'article':
             return self._format_article(data)
         else:
             return self._format_misc(data)
@@ -26,10 +34,10 @@ class RichTextFormatter(TextFormatter):
     def _format_article(self, data):
         result = []
 
-        authors = self._authors(data['authors'])
+        authors = self._authors(data['author'])
 
         if authors:
-            result.append(f"{self._authors(data['authors'])}, ")
+            result.append(f"{self._authors(data['author'])}, ")
 
         if self._use_title:
             result.append(f"{self._encoder.encode(data['title'])}, ")
@@ -38,7 +46,7 @@ class RichTextFormatter(TextFormatter):
             result.append(rf'{{\field{{\*\fldinst HYPERLINK "{data["url"]}"}}{{\fldrslt{{\ul\cf1')
 
         if self._abbreviate_journals:
-            result.append(f"{self._encoder.encode(data['journal-abbrev'])}")
+            result.append(f"{self._encoder.encode(data['journal_abbreviation'])}")
         else:
             result.append(f"{self._encoder.encode(data['journal'])}")
 
@@ -49,7 +57,7 @@ class RichTextFormatter(TextFormatter):
         else:
             result.append(f"  ")
 
-        result.append(f"({data['published-date']['year']})")
+        result.append(f"({data['year']})")
 
         if "url" in data:
             result.append('}}}')
@@ -61,10 +69,10 @@ class RichTextFormatter(TextFormatter):
 
         result = []
 
-        authors = self._authors(data['authors'])
+        authors = self._authors(data['author'])
 
         if authors:
-            result.append(f"{self._authors(data['authors'])}, ")
+            result.append(f"{self._authors(data['author'])}, ")
 
         if self._use_title:
             result.append(f"{self._encoder.encode(data['title'])}, ")
@@ -72,8 +80,8 @@ class RichTextFormatter(TextFormatter):
         if "url" in data:
             result.append(rf'{{\field{{\*\fldinst HYPERLINK "{data["url"]}"}}{{\fldrslt{{\ul\cf1')
 
-        if "journal-abbrev" in data and self._abbreviate_journals:
-            result.append(f"{self._encoder.encode(data['journal-abbrev'])}")
+        if "journal_abbreviation" in data and self._abbreviate_journals:
+            result.append(f"{self._encoder.encode(data['journal_abbreviation'])}")
         elif "journal" in data:
             result.append(f"{self._encoder.encode(data['journal'])}")
 
@@ -90,7 +98,7 @@ class RichTextFormatter(TextFormatter):
         else:
             result.append(f"  ")
 
-        result.append(f"({data['published-date']['year']})")
+        result.append(f"({data['year']})")
 
         if "url" in data:
             result.append('}}}')

--- a/src/blib/formatting/richtext_review.py
+++ b/src/blib/formatting/richtext_review.py
@@ -26,7 +26,7 @@ class RichTextReviewFormatter(TextFormatter):
         return rf'{{\pard {citation} \par}}'
 
     def header(self):
-        return r'{\rtf1\ansi\deff0 '
+        return r'{\rtf1\ansi\deff0{\colortbl;\red0\green0\blue255;\red255\green0\blue0;} '
 
     def footer(self):
         return r'}'

--- a/src/blib/formatting/richtext_review.py
+++ b/src/blib/formatting/richtext_review.py
@@ -18,7 +18,7 @@ class RichTextReviewFormatter(TextFormatter):
 
     def format(self, data):
 
-        if data['entry'] == 'article':
+        if data['bibtex_type'] == 'article':
             citation = self._format_article(data)
         else:
             citation = self._format_misc(data)
@@ -37,13 +37,13 @@ class RichTextReviewFormatter(TextFormatter):
         if self._use_title:
             result.append(f"{self._encoder.encode(data['title'])}, ")
 
-        authors = self._authors(data['authors'])
+        authors = self._authors(data['author'])
 
         if authors:
-            result.append(f"{self._authors(data['authors'])}, ")
+            result.append(f"{self._authors(data['author'])}, ")
 
         if self._abbreviate_journals:
-            result.append(f"{self._encoder.encode(data['journal-abbrev'])}")
+            result.append(f"{self._encoder.encode(data['journal_abbreviation'])}")
         else:
             result.append(f"{self._encoder.encode(data['journal'])}")
 
@@ -57,7 +57,7 @@ class RichTextReviewFormatter(TextFormatter):
         else:
             result.append(f"  ")
 
-        result.append(f"({data['published-date']['year']}); ")
+        result.append(f"({data['year']}); ")
 
         result.append(f"https://doi.org/{data['doi']}")
 
@@ -69,13 +69,13 @@ class RichTextReviewFormatter(TextFormatter):
         if self._use_title:
             result.append(f"{self._encoder.encode(data['title'])}, ")
 
-        authors = self._authors(data['authors'])
+        authors = self._authors(data['author'])
 
         if authors:
-            result.append(f"{self._authors(data['authors'])}, ")
+            result.append(f"{self._authors(data['author'])}, ")
 
         if self._abbreviate_journals:
-            result.append(f"{self._encoder.encode(data['journal-abbrev'])}")
+            result.append(f"{self._encoder.encode(data['journal_abbreviation'])}")
         else:
             result.append(f"{self._encoder.encode(data['journal'])}")
 
@@ -91,7 +91,7 @@ class RichTextReviewFormatter(TextFormatter):
             else:
                 result.append(f"  ")
 
-        result.append(f" ({data['published-date']['year']}); ")
+        result.append(f" ({data['year']}); ")
 
         if 'doi' in data:
             result.append(f"https://doi.org/{data['doi']}")

--- a/src/blib/formatting/tests/bibdesk_autogeneration_examples_test.py
+++ b/src/blib/formatting/tests/bibdesk_autogeneration_examples_test.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+
+from blib.encoding.unicode_encoder import UnicodeEncoder
+from blib.formatting.bibdesk_autogeneration import (
+    BibDeskAutogenerationFormatter,
+    BibDeskFormatError,
+)
+
+
+DOCUMENTATION_BIBLIOGRAPHY = {
+    'bibtex_type': 'article',
+    'author': [
+        {'given': 'M.', 'family': 'McCracken'},
+        {'given': 'A.', 'family': 'Maxwell'},
+        {'given': 'J.', 'family': 'Howison'},
+        {'given': 'M.', 'family': 'Routley'},
+        {'given': 'S.', 'family': 'Spiegel'},
+        {'given': 'S. S.', 'family': 'Porst'},
+        {'given': 'C. M.', 'family': 'Hofman'},
+    ],
+    'title': 'BibDesk, a great application to manage your bibliographies',
+    'journal': 'Source Forge',
+    'journal_abbreviation': 'Source Forge',
+    'volume': '1',
+    'pages': ['96'],
+    'year': '2004',
+    'month': '11',
+}
+
+
+class TestBibDeskAutogenerationDocumentationExamples(TestCase):
+    def _formatter(self, format_string):
+        return BibDeskAutogenerationFormatter(format_string, UnicodeEncoder(), citekey_mode=True)
+
+    def test_example_truncated_authors_and_date(self):
+        citation = self._formatter('%a 03%y%m').format(DOCUMENTATION_BIBLIOGRAPHY)
+
+        self.assertEqual(citation, 'McCMaxHowRouSpiPorHof0411')
+
+    def test_example_author_initials_and_title(self):
+        # The BibDesk examples page shows `%y` producing `2004`, but the syntax table on the
+        # same page defines `%y` as the year without the century. We follow the table semantics.
+        citation = self._formatter('%A[;][.][;etal]2:%y%t 20').format(DOCUMENTATION_BIBLIOGRAPHY)
+
+        self.assertEqual(citation, 'McCracken.M.;Maxwell.A.;etal:04BibDesk-a-great-appl')
+
+    def test_example_field_acronym_and_volume(self):
+        citation = self._formatter('%a[;][;etal]24:%c{Journal}%f{Volume}').format(DOCUMENTATION_BIBLIOGRAPHY)
+
+        self.assertEqual(citation, 'McCr;Maxw;etal:SF1')
+
+    def test_unique_number_example_is_not_supported_yet(self):
+        with self.assertRaisesRegex(BibDeskFormatError, r'specifier %n is not supported'):
+            self._formatter('%a 1:%Y%n').format(DOCUMENTATION_BIBLIOGRAPHY)
+
+    def test_unique_lowercase_example_is_not_supported_yet(self):
+        with self.assertRaisesRegex(BibDeskFormatError, r'specifier %u is not supported'):
+            self._formatter('%a 1:%Y%u[Doi][Title]2').format(DOCUMENTATION_BIBLIOGRAPHY)

--- a/src/blib/formatting/tests/bibdesk_autogeneration_test.py
+++ b/src/blib/formatting/tests/bibdesk_autogeneration_test.py
@@ -1,0 +1,104 @@
+from unittest import TestCase
+
+from blib.formatting.bibdesk_autogeneration import BibDeskAutogenerationFormatter
+from blib.formatting.markdown import MarkdownFormatter
+from blib.formatting.richtext import RichTextFormatter
+from blib.formatting.text_formatter import TextFormatter
+
+
+ARTICLE_DATA = {
+    'bibtex_type': 'article',
+    'author': [
+        {'given': 'Joseph', 'family': 'Barker'},
+        {'given': 'Anna Marie', 'family': 'Maxwell'},
+        {'given': 'Chris', 'family': 'Jones'},
+    ],
+    'title': 'A study of magnetic materials',
+    'journal': 'Journal of Interesting Results',
+    'journal_abbreviation': 'J. Int. Results',
+    'doi': '10.1000/example',
+    'url': 'https://dx.doi.org/10.1000/example',
+    'volume': '42',
+    'number': '7',
+    'pages': ['100', '108'],
+    'publisher': 'Example Press',
+    'year': '2024',
+    'month': '11',
+}
+
+
+MISC_DATA = {
+    'bibtex_type': 'misc',
+    'author': [
+        {'given': 'Jane', 'family': 'Doe'},
+    ],
+    'title': 'Preprint title',
+    'journal': 'arXiv.2401.12345 [cond-mat]',
+    'url': 'https://arxiv.org/abs/2401.12345',
+    'eprint': '2401.12345',
+    'archiveprefix': 'arXiv',
+    'primaryclass': 'cond-mat',
+    'year': 2024,
+    'month': 1,
+}
+
+
+class TestBibDeskAutogenerationFormatter(TestCase):
+    def test_author_title_and_year_template(self):
+        formatter = TextFormatter(format_string='%A[, ][ ]2, %t (%Y)')
+
+        citation = formatter.format(ARTICLE_DATA)
+
+        self.assertEqual(citation, 'Barker J., Maxwell A.M., A study of magnetic materials (2024)')
+
+    def test_title_word_and_field_specifiers(self):
+        formatter = BibDeskAutogenerationFormatter(
+            '%T[3]2 | %c{Journal} | %f{Pages} | %f{Journal Abbreviation} | %f{BibTeX Type}',
+            TextFormatter()._encoder
+        )
+
+        citation = formatter.format(ARTICLE_DATA)
+
+        self.assertEqual(citation, 'A study of magnetic | JIR | 100--108 | J. Int. Results | article')
+
+    def test_markdown_custom_format_replaces_default_template(self):
+        formatter = MarkdownFormatter(format_string='[%f{Cite Key}](%f{Url})')
+
+        citation = formatter.format(ARTICLE_DATA)
+
+        self.assertEqual(citation, '[Barker_JIntResults_42_100_2024](https://dx.doi.org/10.1000/example)')
+
+    def test_etal_suffix_follows_bibdesk_separator_rules(self):
+        formatter = TextFormatter(format_string='%A[;][.][;etal]2')
+
+        citation = formatter.format(ARTICLE_DATA)
+
+        self.assertEqual(citation, 'Barker.J.;Maxwell.A.M.;etal')
+
+    def test_richtext_custom_format_is_rtf_encoded(self):
+        formatter = RichTextFormatter(format_string='%A[, ][ ]1, %t')
+
+        citation = formatter.format({
+            **ARTICLE_DATA,
+            'author': [{'given': 'Amalio', 'family': 'Fernández-Pacheco'}],
+        })
+
+        self.assertTrue(citation.startswith(r'{\pard '))
+        self.assertIn(r'Fern\u225', citation)
+
+    def test_misc_cite_key_is_available(self):
+        formatter = TextFormatter(format_string='%f{Cite Key}')
+
+        citation = formatter.format(MISC_DATA)
+
+        self.assertEqual(citation, 'Doe_2401_12345_2024')
+
+    def test_default_text_formatter_is_unchanged_without_format_string(self):
+        formatter = TextFormatter(use_title=True)
+
+        citation = formatter.format(ARTICLE_DATA)
+
+        self.assertEqual(
+            citation,
+            'J. Barker et al., A study of magnetic materials, J. Int. Results 42, 100 (2024)'
+        )

--- a/src/blib/formatting/text_formatter.py
+++ b/src/blib/formatting/text_formatter.py
@@ -1,4 +1,5 @@
 from blib.encoding.unicode_encoder import UnicodeEncoder
+from blib.formatting.bibdesk_autogeneration import BibDeskAutogenerationFormatter
 from blib.formatting.formatter import Formatter
 
 
@@ -8,27 +9,34 @@ class TextFormatter(Formatter):
                  abbreviate_journals=True,
                  use_title=False,
                  max_authors=1,
-                 etal="et al."):
+                 etal="et al.",
+                 format_string=None):
         self._encoder = UnicodeEncoder()
         self._abbreviate_journals = abbreviate_journals
         self._use_title = use_title
         self._max_authors = max_authors
         self._etal = etal
+        self._format_string = format_string
+        self._bibdesk_formatter = None
+        if format_string:
+            self._bibdesk_formatter = BibDeskAutogenerationFormatter(format_string, self._encoder)
 
     def format(self, data):
+        if self._bibdesk_formatter:
+            return self._bibdesk_formatter.format(data)
 
         result = []
 
-        authors = self._authors(data['authors'])
+        authors = self._authors(data['author'])
 
         if authors:
-            result.append(f"{self._authors(data['authors'])}, ")
+            result.append(f"{self._authors(data['author'])}, ")
 
         if self._use_title:
             result.append(f"{self._encoder.encode(data['title'])}, ")
 
         if self._abbreviate_journals:
-            result.append(f"{self._encoder.encode(data['journal-abbrev'])}")
+            result.append(f"{self._encoder.encode(data['journal_abbreviation'])}")
         else:
             result.append(f"{self._encoder.encode(data['journal'])}")
 
@@ -37,7 +45,7 @@ class TextFormatter(Formatter):
         except TypeError:
             pages = data['pages']
 
-        result.append(f" {data['volume']}, {pages} ({data['published-date']['year']})")
+        result.append(f" {data['volume']}, {pages} ({data['year']})")
 
         return ''.join(result)
 

--- a/src/blib/main.py
+++ b/src/blib/main.py
@@ -283,6 +283,10 @@ def main():
     parser.add_argument('--etal', type=str, help='text to use for "et al"',
                         default = "et al.")
 
+    parser.add_argument('--format', type=str,
+                        help='BibDesk autogeneration format string used by md/txt/rtf output',
+                        default=None)
+
 
     args = parser.parse_args()
 
@@ -316,21 +320,24 @@ def main():
             abbreviate_journals=args.abbrev,
             use_title=args.title,
             max_authors=args.authors,
-            etal=args.etal
+            etal=args.etal,
+            format_string=args.format
         )
     elif args.output == 'txt':
         formatter = TextFormatter(
             abbreviate_journals=args.abbrev,
             use_title=args.title,
             max_authors=args.authors,
-            etal=args.etal
+            etal=args.etal,
+            format_string=args.format
         )
     elif args.output == 'rtf':
         formatter = RichTextFormatter(
             abbreviate_journals=args.abbrev,
             use_title=args.title,
             max_authors=args.authors,
-            etal=args.etal
+            etal=args.etal,
+            format_string=args.format
         )
     elif args.output == 'review':
         formatter = RichTextReviewFormatter(
@@ -370,4 +377,3 @@ def main():
         copy_to_clipboard(''.join(results))
 
     print(''.join(results))
-

--- a/src/blib/main.py
+++ b/src/blib/main.py
@@ -39,6 +39,15 @@ DOI_REGEX = r'10\.\d{4,}(?:\.\d+)*\/(?!\(ISSN\))[^\s"\'<>]*[^\s"\'<>\.,;:?!\)]'
 
 # https://arxiv.org/help/arxiv_identifier
 ARXIV_REGEX = r'ar[xX]iv.*([0-9]{2}[0-1][0-9]\.[0-9]{4,}(?:v[0-9]+)?)'
+ORCID_REGEX = r'^\d{4}-\d{4}-\d{4}-\d{4}$'
+
+
+def is_valid_orcid(orcid):
+    if not re.match(ORCID_REGEX, orcid):
+        raise argparse.ArgumentTypeError(
+            'ORCID must be in the format 0000-0000-0000-0000'
+        )
+    return orcid
 
 def is_url(string):
     try:
@@ -258,12 +267,59 @@ def copy_to_clipboard(text):
     #     raise RuntimeError(f"unsupported clipboard platform {sys.platform}")
 
 
+def resource_ids_from_args(items):
+    resource_id_list = []
+
+    for item in items:
+        # check if the item is a file or a plain string
+        if os.path.isfile(os.path.expanduser(item)):
+            filepath = os.path.expanduser(item)
+            mimetype, _ = mimetypes.guess_type(filepath)
+            if (mimetype == 'application/pdf') or (mimetype == 'application/x-pdf'):
+                # file is a pdf file
+                if doi := find_resource_id_from_pdf(filepath):
+                    resource_id_list.append(doi)
+            else:
+                # assume file is a text file
+                with open(filepath) as f:
+                    for line in f:
+                        resource_ids = find_all_resource_ids(line)
+                        if resource_ids:
+                            resource_id_list += resource_ids
+
+        elif is_url(item):
+            if doi := doi_from_webpage_meta_data(item):
+                resource_id_list.append(doi)
+        else:
+            if resource_id := find_resource_id(item):
+                resource_id_list.append(resource_id)
+
+    return resource_id_list
+
+
+def append_result(results, text, output_format):
+    if output_format in ('rtf', 'review'):
+        results.append(f'{text}\n')
+    else:
+        results.append(text)
+
+
+def format_lookup_error(resource_id, output_format):
+    if output_format in ('rtf', 'review'):
+        return rf'{{\pard \cf2 // failed DOI lookup: {resource_id.id} \cf0 \par}}'
+    return f'\n// failed DOI lookup: {resource_id.id}\n\n'
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='fetch bibtex entries from a list of strings containing DOIs. '
     )
 
     parser.add_argument('doi', nargs='*', help='a string containing a doi')
+
+    parser.add_argument('--orcid', type=is_valid_orcid,
+                        help='ORCID iD in the format 0000-0000-0000-0000',
+                        default=None)
 
     parser.add_argument('--output', help='output format (default: %(default)s)',
                         default='bib', choices=['md', 'bib', 'txt', 'rtf', 'review', 'doi', 'data'])
@@ -290,26 +346,11 @@ def main():
 
     args = parser.parse_args()
 
-    resource_id_list = []
-
-    for item in args.doi:
-        # check if the item is a file or a plain string
-        if os.path.isfile(os.path.expanduser(item)):
-            filepath = os.path.expanduser(item)
-            mimetype, _ = mimetypes.guess_type(filepath)
-            if (mimetype == 'application/pdf') or (mimetype == 'application/x-pdf'):
-                # file is a pdf file
-                if doi := find_resource_id_from_pdf(filepath): resource_id_list.append(doi)
-            else:
-                # assume file is a text file
-                with open(filepath) as f:
-                    for line in f:
-                        resource_id_list += find_all_resource_ids(line)
-
-        elif is_url(item):
-            if doi := doi_from_webpage_meta_data(item): resource_id_list.append(doi)
-        else:
-            if resource_id := find_resource_id(item): resource_id_list.append(resource_id)
+    if args.orcid:
+        orcid_resolver = blib.providers.OrcidProvider()
+        resource_id_list = orcid_resolver.request(args.orcid)
+    else:
+        resource_id_list = resource_ids_from_args(args.doi)
 
     if args.output == 'bib':
         formatter = BibtexFormatter(
@@ -359,15 +400,15 @@ def main():
             try:
                 text = formatter.format(doi_resolver.request(resource_id.id))
                 if text:
-                    results.append(text)
+                    append_result(results, text, args.output)
             except (DoiTypeError, URLError) as e:
-                results.append(f'\n// {e}\n\n')
+                append_result(results, format_lookup_error(resource_id, args.output), args.output)
 
         if resource_id.type == ResourceIdType.arxiv:
             try:
                 text = formatter.format(arxiv_resolver.request(resource_id.id))
                 if text:
-                    results.append(text)
+                    append_result(results, text, args.output)
             except URLError as e:
                 results.append(f'\n// {e}\n\n')
 

--- a/src/blib/main_test.py
+++ b/src/blib/main_test.py
@@ -1,0 +1,102 @@
+import io
+from urllib.error import URLError
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from blib.main import is_valid_orcid, main
+from blib.resourceid import ResourceId, ResourceIdType
+
+
+class TestMain(TestCase):
+    def test_is_valid_orcid_accepts_expected_format(self):
+        self.assertEqual(is_valid_orcid('0000-0003-4843-5516'), '0000-0003-4843-5516')
+
+    def test_is_valid_orcid_rejects_invalid_format(self):
+        with self.assertRaisesRegex(Exception, 'ORCID must be in the format'):
+            is_valid_orcid('0000-0003-4843-XXXX')
+
+    def test_orcid_mode_processes_dois_and_continues_after_failures(self):
+        orcid_resolver = MagicMock()
+        orcid_resolver.request.return_value = [
+            ResourceId('10.1000/a', ResourceIdType.doi),
+            ResourceId('10.1000/bad', ResourceIdType.doi),
+            ResourceId('10.1000/b', ResourceIdType.doi),
+        ]
+
+        doi_resolver = MagicMock()
+        doi_resolver.request.side_effect = [
+            {'doi': '10.1000/a'},
+            URLError('not found'),
+            {'doi': '10.1000/b'},
+        ]
+
+        with patch('sys.argv', ['blib', '--output', 'doi', '--no-clip', '--orcid', '0000-0003-4843-5516']), \
+             patch('blib.main.blib.providers.OrcidProvider', return_value=orcid_resolver), \
+             patch('blib.main.blib.providers.CrossrefProvider', return_value=doi_resolver), \
+             patch('blib.main.blib.providers.ArxivProvider'), \
+             patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            main()
+
+        output = stdout.getvalue()
+
+        orcid_resolver.request.assert_called_once_with('0000-0003-4843-5516')
+        self.assertIn('10.1000/a', output)
+        self.assertIn('// failed DOI lookup: 10.1000/bad', output)
+        self.assertIn('10.1000/b', output)
+        self.assertLess(output.find('10.1000/a'), output.find('// failed DOI lookup: 10.1000/bad'))
+        self.assertLess(output.find('// failed DOI lookup: 10.1000/bad'), output.rfind('10.1000/b'))
+
+    def test_rtf_output_uses_one_visible_line_per_entry(self):
+        doi_resolver = MagicMock()
+        doi_resolver.request.side_effect = [
+            {
+                'bibtex_type': 'article',
+                'author': [{'given': 'Joseph', 'family': 'Barker'}],
+                'title': 'Paper One',
+                'journal': 'Journal One',
+                'journal_abbreviation': 'J. One',
+                'volume': '1',
+                'pages': ['10'],
+                'year': '2024',
+                'url': 'https://doi.org/10.1000/one',
+            },
+            {
+                'bibtex_type': 'article',
+                'author': [{'given': 'Joseph', 'family': 'Barker'}],
+                'title': 'Paper Two',
+                'journal': 'Journal Two',
+                'journal_abbreviation': 'J. Two',
+                'volume': '2',
+                'pages': ['20'],
+                'year': '2025',
+                'url': 'https://doi.org/10.1000/two',
+            },
+        ]
+
+        with patch('sys.argv', ['blib', '--output', 'rtf', '--no-clip', '10.1000/one', '10.1000/two']), \
+             patch('blib.main.blib.providers.CrossrefProvider', return_value=doi_resolver), \
+             patch('blib.main.blib.providers.ArxivProvider'), \
+             patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            main()
+
+        output = stdout.getvalue()
+
+        self.assertIn(r'{\rtf1\ansi\deff0{\colortbl;', output)
+        self.assertIn('Paper One', output)
+        self.assertIn('Paper Two', output)
+        self.assertIn('\\par}\n{\\pard', output)
+
+    def test_rtf_doi_lookup_failures_are_red_paragraphs(self):
+        doi_resolver = MagicMock()
+        doi_resolver.request.side_effect = URLError('not found')
+
+        with patch('sys.argv', ['blib', '--output', 'rtf', '--no-clip', '10.1000/missing']), \
+             patch('blib.main.blib.providers.CrossrefProvider', return_value=doi_resolver), \
+             patch('blib.main.blib.providers.ArxivProvider'), \
+             patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            main()
+
+        output = stdout.getvalue()
+
+        self.assertIn(r'{\rtf1\ansi\deff0{\colortbl;', output)
+        self.assertIn(r'{\pard \cf2 // failed DOI lookup: 10.1000/missing \cf0 \par}', output)

--- a/src/blib/providers/__init__.py
+++ b/src/blib/providers/__init__.py
@@ -1,3 +1,4 @@
 from blib.providers.provider import Provider
 from blib.providers.crossref_provider import CrossrefProvider
 from blib.providers.arxiv_provider import ArxivProvider
+from blib.providers.orcid_provider import OrcidProvider

--- a/src/blib/providers/arxiv_provider.py
+++ b/src/blib/providers/arxiv_provider.py
@@ -44,15 +44,15 @@ class ArxivProvider(Provider):
 
         # We use some private methods to normalise the data
         result = {
-            'entry':          'misc',
-            'authors':        self._authors(root),
-            'title':          self._title(root),
-            'journal':        self._journal(root),
-            'url':            self._url(root),
-            'eprint':         arxiv_id.removeprefix("arxiv."),
-            'published-date': self._published_date(root),
+            'bibtex_type': 'misc',
+            'author': self._authors(root),
+            'title': self._title(root),
+            'journal': self._journal(root),
+            'url': self._url(root),
+            'eprint': arxiv_id.removeprefix("arxiv."),
             'archiveprefix': 'arXiv',
             'primaryclass': self._category(root),
+            **self._published_date(root),
         }
 
         if has_diskcache:

--- a/src/blib/providers/crossref_provider.py
+++ b/src/blib/providers/crossref_provider.py
@@ -49,18 +49,18 @@ class CrossrefProvider(Provider):
 
         # We use some private methods to normalise the data
         result = {
-            'authors':        self._authors(jdata),
-            'title':          self._title(jdata),
-            'journal':        self._journal(jdata),
-            'journal-abbrev': self._journal_abbrev(jdata),
-            'doi':            self._doi(jdata),
-            'url':            self._url(jdata),
-            'entry':          'article',
-            'issue':          self._issue(jdata),
-            'volume':         self._volume(jdata),
-            'pages':          self._pages(jdata),
-            'publisher':      self._publisher(jdata),
-            'published-date': self._published_date(jdata)}
+            'author':               self._authors(jdata),
+            'title':                self._title(jdata),
+            'journal':              self._journal(jdata),
+            'journal_abbreviation': self._journal_abbrev(jdata),
+            'doi':                  self._doi(jdata),
+            'url':                  self._url(jdata),
+            'bibtex_type':          'article',
+            'number':               self._issue(jdata),
+            'volume':               self._volume(jdata),
+            'pages':                self._pages(jdata),
+            'publisher':            self._publisher(jdata),
+            **self._published_date(jdata)}
 
         if has_diskcache:
             self._cache[doi] = result

--- a/src/blib/providers/orcid_provider.py
+++ b/src/blib/providers/orcid_provider.py
@@ -1,0 +1,167 @@
+import json
+from dataclasses import dataclass
+from typing import Optional
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from blib.resourceid import ResourceId, ResourceIdType
+from blib.providers.provider import Provider
+
+BLIB_HTTP_USER_AGENT = r'blib/0.1 (https://github.com/drjbarker/blib; mailto:j.barker@leeds.ac.uk)'
+
+
+@dataclass
+class OrcidWork:
+    doi: str
+    year: Optional[int]
+    month: Optional[int]
+    day: Optional[int]
+    position: int
+
+
+class OrcidProvider(Provider):
+    def request(self, orcid):
+        url = f'https://pub.orcid.org/v3.0/{orcid}/works'
+        with urlopen(Request(url, headers={
+            'User-Agent': BLIB_HTTP_USER_AGENT,
+            'Accept': 'application/json',
+        })) as response:
+            if response.code != 200:
+                raise URLError(f"failed to resolve {url}")
+
+            data = json.loads(response.read().decode('utf-8'))
+
+        works = self._parse_works(data)
+        return [ResourceId(work.doi, ResourceIdType.doi) for work in works]
+
+    def _parse_works(self, data):
+        unique_works = {}
+
+        for position, group in enumerate(data.get('group', [])):
+            work = self._work_from_group(group, position)
+            if work is None:
+                continue
+
+            if work.doi not in unique_works:
+                unique_works[work.doi] = work
+                continue
+
+            existing = unique_works[work.doi]
+            if self._sort_key(work) < self._sort_key(existing):
+                unique_works[work.doi] = work
+
+        return sorted(unique_works.values(), key=self._sort_key)
+
+    def _work_from_group(self, group, position):
+        summary = self._preferred_summary(group)
+        if summary is not None:
+            doi = self._first_doi(summary.get('external-ids', {}))
+            if doi:
+                year, month, day = self._summary_publication_date(summary)
+                if year is None:
+                    year, month, day = self._group_publication_date(group)
+                return OrcidWork(
+                    doi=doi.lower(),
+                    year=year,
+                    month=month,
+                    day=day,
+                    position=position,
+                )
+
+        doi = self._first_doi(group.get('external-ids', {}))
+        if doi is None:
+            return None
+
+        year, month, day = self._group_publication_date(group)
+        return OrcidWork(
+            doi=doi.lower(),
+            year=year,
+            month=month,
+            day=day,
+            position=position,
+        )
+
+    def _sort_key(self, work):
+        has_date = work.year is not None
+        return (
+            0 if has_date else 1,
+            work.year if work.year is not None else 9999,
+            work.month if work.month is not None else 99,
+            work.day if work.day is not None else 99,
+            work.position,
+            work.doi,
+        )
+
+    def _group_publication_date(self, group):
+        dates = []
+        for summary in group.get('work-summary', []):
+            year, month, day = self._summary_publication_date(summary)
+            if year is None:
+                continue
+
+            completeness = sum(value is not None for value in (year, month, day))
+            dates.append((year, month, day, -completeness))
+
+        if not dates:
+            return None, None, None
+
+        year, month, day, _ = min(
+            dates,
+            key=lambda value: (
+                value[0],
+                value[1] if value[1] is not None else 99,
+                value[2] if value[2] is not None else 99,
+                value[3],
+            )
+        )
+        return year, month, day
+
+    def _summary_publication_date(self, summary):
+        publication_date = summary.get('publication-date') or {}
+        year = self._date_value(publication_date, 'year')
+        month = self._date_value(publication_date, 'month')
+        day = self._date_value(publication_date, 'day')
+        return year, month, day
+
+    def _date_value(self, publication_date, key):
+        value = publication_date.get(key)
+        if not value or value.get('value') is None:
+            return None
+        return int(value['value'])
+
+    def _preferred_summary(self, group):
+        summaries = group.get('work-summary', [])
+
+        for summary in summaries:
+            if self._is_crossref_summary(summary) and self._first_doi(summary.get('external-ids', {})):
+                return summary
+
+        for summary in summaries:
+            if self._first_doi(summary.get('external-ids', {})):
+                return summary
+
+        return None
+
+    def _is_crossref_summary(self, summary):
+        source = summary.get('source') or {}
+        source_name = source.get('source-name') or {}
+        return str(source_name.get('value', '')).strip().lower() == 'crossref'
+
+    def _first_doi(self, external_ids):
+        dois = self._external_ids_to_dois(external_ids)
+        if dois:
+            return dois[0]
+        return None
+
+    def _external_ids_to_dois(self, external_ids):
+        result = []
+        for external_id in external_ids.get('external-id', []):
+            if external_id.get('external-id-type', '').lower() != 'doi':
+                continue
+
+            normalized = external_id.get('external-id-normalized', {}) or {}
+            value = normalized.get('value') or external_id.get('external-id-value')
+            if value:
+                result.append(value)
+
+        return result

--- a/src/blib/providers/orcid_provider_test.py
+++ b/src/blib/providers/orcid_provider_test.py
@@ -1,0 +1,198 @@
+from unittest import TestCase
+
+from blib.providers.orcid_provider import OrcidProvider
+
+
+class TestOrcidProvider(TestCase):
+    def test_parse_works_deduplicates_and_sorts_chronologically(self):
+        provider = OrcidProvider()
+
+        payload = {
+            'group': [
+                {
+                    'external-ids': {
+                        'external-id': [
+                            {
+                                'external-id-type': 'doi',
+                                'external-id-value': '10.1000/B',
+                            }
+                        ]
+                    },
+                    'work-summary': [
+                        {
+                            'publication-date': {
+                                'year': {'value': '2025'},
+                                'month': {'value': '03'},
+                                'day': {'value': '10'},
+                            }
+                        }
+                    ],
+                },
+                {
+                    'work-summary': [
+                        {
+                            'external-ids': {
+                                'external-id': [
+                                    {
+                                        'external-id-type': 'doi',
+                                        'external-id-normalized': {'value': '10.1000/a'},
+                                    }
+                                ]
+                            },
+                            'publication-date': {
+                                'year': {'value': '2024'},
+                                'month': {'value': '12'},
+                                'day': {'value': '01'},
+                            }
+                        }
+                    ],
+                },
+                {
+                    'external-ids': {
+                        'external-id': [
+                            {
+                                'external-id-type': 'doi',
+                                'external-id-normalized': {'value': '10.1000/b'},
+                            }
+                        ]
+                    },
+                    'work-summary': [
+                        {
+                            'publication-date': {
+                                'year': {'value': '2025'},
+                                'month': {'value': '02'},
+                                'day': {'value': '20'},
+                            }
+                        }
+                    ],
+                },
+                {
+                    'external-ids': {
+                        'external-id': [
+                            {
+                                'external-id-type': 'eid',
+                                'external-id-value': '2-s2.0-123',
+                            },
+                            {
+                                'external-id-type': 'doi',
+                                'external-id-value': '10.1000/c',
+                            }
+                        ]
+                    },
+                    'work-summary': [
+                        {
+                            'publication-date': {
+                                'year': None,
+                                'month': None,
+                                'day': None,
+                            }
+                        }
+                    ],
+                },
+            ]
+        }
+
+        works = provider._parse_works(payload)
+
+        self.assertEqual([work.doi for work in works], ['10.1000/a', '10.1000/b', '10.1000/c'])
+        self.assertEqual((works[0].year, works[0].month, works[0].day), (2024, 12, 1))
+        self.assertEqual((works[1].year, works[1].month, works[1].day), (2025, 2, 20))
+        self.assertEqual((works[2].year, works[2].month, works[2].day), (None, None, None))
+
+    def test_parse_works_prefers_crossref_source_and_returns_one_doi_per_group(self):
+        provider = OrcidProvider()
+
+        payload = {
+            'group': [
+                {
+                    'work-summary': [
+                        {
+                            'source': {
+                                'source-name': {'value': 'Scopus - Elsevier'},
+                            },
+                            'external-ids': {
+                                'external-id': [
+                                    {
+                                        'external-id-type': 'doi',
+                                        'external-id-value': '10.1000/elsevier',
+                                    }
+                                ]
+                            },
+                            'publication-date': {
+                                'year': {'value': '2025'},
+                                'month': {'value': '02'},
+                                'day': {'value': '02'},
+                            },
+                        },
+                        {
+                            'source': {
+                                'source-name': {'value': 'Crossref'},
+                            },
+                            'external-ids': {
+                                'external-id': [
+                                    {
+                                        'external-id-type': 'doi',
+                                        'external-id-value': '10.1000/crossref',
+                                    }
+                                ]
+                            },
+                            'publication-date': {
+                                'year': {'value': '2025'},
+                                'month': {'value': '01'},
+                                'day': {'value': '15'},
+                            },
+                        },
+                    ],
+                },
+                {
+                    'work-summary': [
+                        {
+                            'source': {
+                                'source-name': {'value': 'Joseph Barker via Scopus - Elsevier'},
+                            },
+                            'external-ids': {
+                                'external-id': [
+                                    {
+                                        'external-id-type': 'doi',
+                                        'external-id-value': '10.1000/first-source',
+                                    },
+                                    {
+                                        'external-id-type': 'doi',
+                                        'external-id-value': '10.1000/second-doi',
+                                    }
+                                ]
+                            },
+                            'publication-date': {
+                                'year': {'value': '2024'},
+                                'month': {'value': '10'},
+                                'day': {'value': '05'},
+                            },
+                        },
+                        {
+                            'source': {
+                                'source-name': {'value': 'Another Source'},
+                            },
+                            'external-ids': {
+                                'external-id': [
+                                    {
+                                        'external-id-type': 'doi',
+                                        'external-id-value': '10.1000/later-source',
+                                    }
+                                ]
+                            },
+                            'publication-date': {
+                                'year': {'value': '2024'},
+                                'month': {'value': '11'},
+                                'day': {'value': '01'},
+                            },
+                        },
+                    ],
+                },
+            ]
+        }
+
+        works = provider._parse_works(payload)
+
+        self.assertEqual([work.doi for work in works], ['10.1000/first-source', '10.1000/crossref'])
+        self.assertEqual((works[0].year, works[0].month, works[0].day), (2024, 10, 5))
+        self.assertEqual((works[1].year, works[1].month, works[1].day), (2025, 1, 15))


### PR DESCRIPTION
## Summary
- add BibDesk-style autogeneration formatting support for `md`, `txt`, and `rtf` output
- normalize blib bibliography field names to align with the formatter field model
- add `--orcid` support that fetches ORCID works, prefers Crossref-sourced DOIs, de-duplicates, and sorts chronologically when possible
- render RTF DOI lookup failures as red paragraphs and improve raw RTF output line separation
- add unit tests for BibDesk documentation examples, ORCID parsing, and CLI behavior, and expand README documentation

## Testing
- `PYTHONPYCACHEPREFIX=/tmp/blib-pyc ./venv/bin/python -m unittest discover -s src/blib/formatting/tests -p '*test.py' -q`
- `PYTHONPYCACHEPREFIX=/tmp/blib-pyc ./venv/bin/python -m unittest -q blib.main_test blib.providers.orcid_provider_test`
- live ORCID verification against `0000-0003-4843-5516` during development